### PR TITLE
create_decision_tree(): target is not in list

### DIFF
--- a/dtree.py
+++ b/dtree.py
@@ -551,6 +551,7 @@ def create_decision_tree(data, attributes, class_attr, fitness_func, wrapper, **
     split_attr = kwargs.get('split_attr', None)
     split_val = kwargs.get('split_val', None)
     
+    assert class_attr not in attributes
     node = None
     data = list(data) if isinstance(data, Data) else data
     if wrapper.is_continuous_class:
@@ -565,10 +566,10 @@ def create_decision_tree(data, attributes, class_attr, fitness_func, wrapper, **
         # classification.
         stop = len(stop_value.counts) <= 1
 
-    if not data or (len(attributes) - 1) <= 0:
+    if not data or len(attributes) <= 0:
         # If the dataset is empty or the attributes list is empty, return the
-        # default value. When checking the attributes list for emptiness, we
-        # need to subtract 1 to account for the target attribute.
+        # default value. The target attribute is not in the attributes list, so
+        # we need not subtract 1 to account for the target attribute.
         if wrapper:
             wrapper.leaf_count += 1
         return stop_value


### PR DESCRIPTION
Ever since this project's initial release, the "attributes" parameter to
create_decision_tree() has been initialized (at the only non-recursive
callsite) from Data.attribute_names, and Data.attribute_names has
filtered out the class attribute name. As such, the comment which this
commit changes, is inaccurate: the target attribute is specifically
*not* in "attributes". The effect of this was that the algorithm would
stop splitting one attribute too soon, and thus every leaf node would
always contain a non-trivial probability distribution of classifications
(conditional, in some unknown way, on the unsplit attribute), but never
a single classification with P=1 even when such classifications were
possible.